### PR TITLE
Remove Red Cross from links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,16 +34,6 @@ function App() {
           />
         </a>
         <a
-          href="https://donate.redcrossredcrescent.org/ua/donate/~my-donation?_cv=1"
-          target="_blank"
-          rel="nofollow noopener"
-        >
-          <img
-            src="https://pt.savefrom.net/assets/experiment/supportUkraine/img/fonds/3.png"
-            alt="fond-1"
-          />
-        </a>
-        <a
           href="https://dobro.ua/en/projects/category/zdorovia"
           target="_blank"
           rel="nofollow noopener"


### PR DESCRIPTION
Removed Red Cross donation link, as they spending money in a terrible way.
Sources:
https://mobile.twitter.com/your_psychoo/status/1507110118906863617?s=21&t=8Wz67Xfp19a3lT6r0VaIwg
https://life.pravda.com.ua/society/2022/03/26/247987/
https://telegraf.com.ua/ukr/ukraina/2022-03-25/5700516-na-krasnom-kreste-mozhno-stavit-krest-ukraintsev-vozmutili-strannye-dogovorennosti-s-lavrovym
https://nv.ua/ukr/ukraine/events/chervoniy-hrest-skandal-z-ofisom-u-rostovi-nacionalniy-komitet-poyasniv-situaciyu-novini-ukrajini-50228742.html